### PR TITLE
(v0.1.4) fix: simplify release workflow for reliability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,20 +19,15 @@ jobs:
       with:
         python-version: "3.12"
     
-    - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
     - name: Install build dependencies
-      run: uv pip install build twine
+      run: python -m pip install --upgrade pip build twine
 
     - name: Build package
       run: python -m build
     
-    - name: Test wheel with uvx
+    - name: Test wheel
       run: |
-        uvx install dist/*.whl
+        python -m pip install dist/*.whl
         mcp-server-make --help
 
     - name: Publish to PyPI


### PR DESCRIPTION
Remove UV/UVX complexity from the release workflow and use standard pip for all package operations. Changes include:

- Use standard pip for installing build dependencies
- Remove UV/UVX specific commands
- Simplify wheel testing process
- Use basic pip install for verification

The changes make the release process more reliable by using standard Python packaging tools rather than introducing additional complexity.