### PR TITLE
chore: bump version to 0.1.5 and add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mcp-server-make
 
+[![CI](https://github.com/modelcontextprotocol/mcp-server-make/actions/workflows/ci.yml/badge.svg)](https://github.com/modelcontextprotocol/mcp-server-make/actions/workflows/ci.yml)
+[![Release](https://github.com/modelcontextprotocol/mcp-server-make/actions/workflows/release.yml/badge.svg)](https://github.com/modelcontextprotocol/mcp-server-make/actions/workflows/release.yml)
+[![PyPI version](https://badge.fury.io/py/mcp-server-make.svg)](https://badge.fury.io/py/mcp-server-make)
+
 MCP Server for GNU Make - providing controlled and secure access to Make systems from LLMs.
 
 ## Features
@@ -123,7 +127,7 @@ npx @modelcontextprotocol/inspector uv --directory /path/to/mcp-server-make run 
 
 ## Security Features
 
-Version 0.1.0 implements several security controls:
+Version 0.1.5 implements several security controls:
 
 - Path validation and directory boundary enforcement
 - Target name sanitization and command validation
@@ -154,7 +158,7 @@ Version 0.1.0 implements several security controls:
 
 ## Known Limitations
 
-Version 0.1.0 has the following scope limitations:
+Version 0.1.5 has the following scope limitations:
 
 - Read-only Makefile access
 - Single Makefile per working directory
@@ -180,6 +184,11 @@ MIT - See LICENSE file for details.
 - GitHub Discussions: Questions and community help
 
 ## Version History
+
+### 0.1.5
+- Version bump
+- Added workflow status badges
+- Bug fixes and improvements
 
 ### 0.1.0
 - Initial stable release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-make"
-version = "0.1.0"
+version = "0.1.5"
 description = "MCP Server for GNU Make"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcp_server_make/__init__.py
+++ b/src/mcp_server_make/__init__.py
@@ -9,7 +9,7 @@ from . import execution
 from . import handlers
 from .server import main as async_main
 
-__version__ = "0.1.0"
+__version__ = "0.1.5"
 __all__ = ["main", "exceptions", "make", "security", "execution", "handlers"]
 
 

--- a/src/mcp_server_make/server.py
+++ b/src/mcp_server_make/server.py
@@ -125,7 +125,7 @@ async def main():
     async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
         init_options = InitializationOptions(
             server_name="mcp-server-make",
-            server_version="0.1.0",
+            server_version="0.1.5",
             capabilities=server.get_capabilities(
                 notification_options=NotificationOptions(),
                 experimental_capabilities={},


### PR DESCRIPTION
- Bump version to 0.1.5 in pyproject.toml, __init__.py, and server.py
- Add CI, Release, and PyPI badges to README.md
- Update documentation to reflect new version
- Add version change entry to history section

Files modified:
- pyproject.toml
- src/mcp_server_make/__init__.py
- src/mcp_server_make/server.py
- README.md