### PR TITLE
v0.2.0 - fix: improve subprocess error handling in make tool

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-make"
-version = "0.1.11"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
- Return errors as TextContent instead of raising exceptions
- Add proper subprocess cleanup on cancellation
- Improve error messages by including both stderr and stdout
- Add start_new_session=True for better process management
- Handle process creation and communication errors separately
- Add proper encoding error handling for output decoding

This should fix the "unhandled errors in TaskGroup" issue by ensuring all subprocess-related errors are properly caught and returned as tool results rather than propagating to the TaskGroup level.

Future improvements to consider:
- Add timeout handling for long-running make commands
- Add progress reporting for long-running targets
- Consider adding stream output for real-time feedback

related: #14 