### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A Model Context Protocol server that provides make functionality. This server enables LLMs to execute make targets from a Makefile in a safe, controlled way.
 
+<a href="https://glama.ai/mcp/servers/g8rwy0077w">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/g8rwy0077w/badge" alt="Server Make MCP server" />
+</a>
+
 ## Overview
 
 The server exposes make functionality through the Model Context Protocol, allowing LLMs like Claude to:


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Make](https://glama.ai/mcp/servers/g8rwy0077w) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/g8rwy0077w">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/g8rwy0077w/badge" alt="Server Make MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.