### PR TITLE
docs: add comprehensive user guide with custom Makefile documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Release](https://github.com/wrale/mcp-server-make/actions/workflows/release.yml/badge.svg)](https://github.com/wrale/mcp-server-make/actions/workflows/release.yml)
 [![PyPI version](https://badge.fury.io/py/mcp-server-make.svg)](https://badge.fury.io/py/mcp-server-make)
 
-A Model Context Protocol server that provides make functionality. This server enables LLMs to execute make targets from a Makefile in a safe, controlled way.
+A Model Context Protocol server that provides make functionality. This server enables LLMs to execute make targets from any Makefile in a safe, controlled way.
 
 <a href="https://glama.ai/mcp/servers/g8rwy0077w">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/g8rwy0077w/badge" alt="Server Make MCP server" />
@@ -19,7 +19,11 @@ The server exposes make functionality through the Model Context Protocol, allowi
 - Handle errors appropriately
 - Respect working directory context
 
-## Installation
+MCP Server Make works with any valid Makefile - you can use the included opinionated Makefile or your own custom build scripts.
+
+## Quick Start
+
+### Installation
 
 Using `uv` (recommended):
 ```bash
@@ -30,8 +34,6 @@ Using pip:
 ```bash
 pip install mcp-server-make
 ```
-
-## Configuration
 
 ### Basic Usage
 ```bash
@@ -61,6 +63,13 @@ To use with Claude Desktop, add to your Claude configuration (`claude_desktop_co
 }
 ```
 
+## Documentation
+
+For detailed information about using MCP Server Make, please see our documentation:
+
+- [User Guide](docs/user_guide.md) - Complete guide to installation, configuration, and usage
+- [Custom Makefiles](docs/custom_makefiles.md) - Creating effective Makefiles for use with MCP Server Make
+
 ## Enhancing Development Workflows
 
 This server enables powerful development workflows by giving LLMs direct access to make functionality:
@@ -71,55 +80,39 @@ This server enables powerful development workflows by giving LLMs direct access 
    - Let Claude run and interpret test results 
    - Get build system suggestions and improvements
    - Automate repetitive development tasks
-   - Get immediate feedback on changes
 
 2. **Project Management**
    - Let Claude handle dependency updates
    - Automate release processes
    - Maintain consistent code quality
-   - Track project status
 
-### For Claude
+### Working with Make Targets
 
-1. **Self-Validation Capabilities**
-   - Run tests to verify changes: `make test`
-   - Check code quality: `make lint`
-   - Format code: `make format`
-   - Full validation: `make check`
+MCP Server Make does not automatically discover available targets in your Makefile. To effectively use it with Claude:
 
-2. **Project Understanding**
-   - View project structure: `make x`
-   - Check recent changes: `make z`
-   - Full context snapshot: `make r`
+1. **Start with `make help`**: Most well-designed Makefiles include a help target
 
-3. **Independent Development**
-   - Manage complete development cycles
-   - Self-contained testing and validation
-   - Build and prepare releases
-   - Generate informed commit messages
+   ```
+   Human: Please run make help to see what commands are available.
+   ```
 
-## Available Tools
+2. **Tell Claude about your targets**: Explicitly mention available targets and their purpose
 
-The server exposes a single tool:
+   ```
+   Human: Our project has these make targets: test, lint, format, build, and clean.
+   ```
 
-- `make` - Run a make target from the Makefile
-    - `target` (string, required): Target name to execute
+3. **Use standard conventions**: Common targets that many Makefiles include:
 
-## Error Handling
+   - `make test` - Run tests
+   - `make lint` - Check code quality 
+   - `make format` - Format code
+   - `make build` - Build the project
+   - `make clean` - Clean build artifacts
 
-The server handles common errors gracefully:
-- Missing Makefile
-- Invalid working directory
-- Failed make commands
-- Invalid targets
+The repository includes an opinionated Makefile with additional utility targets - see the [User Guide](docs/user_guide.md) for details on these extended capabilities or for creating your own custom targets.
 
-All errors are returned with descriptive messages through the MCP protocol.
-
-## Working Directory Behavior
-
-- If `--working-dir` is specified, changes to that directory before executing make
-- If omitted, uses the directory containing the Makefile
-- Always restores original working directory after execution
+> **Note**: Claude doesn't remember available targets between conversations. You'll need to introduce them at the start of each conversation.
 
 ## Example Integration
 
@@ -142,14 +135,12 @@ Running tests...
 All formatting and tests completed successfully. The code is now properly formatted and all tests are passing.
 ```
 
-## Troubleshooting
+## Available Tools
 
-Common issues:
+The server exposes a single tool:
 
-1. **"Makefile not found"**: Verify the --make-path points to a valid Makefile
-2. **"Working directory error"**: Ensure --working-dir exists and is accessible
-3. **"Tool execution failed"**: Check make target exists and command succeeds
-4. **"Permission denied"**: Verify file and directory permissions
+- `make` - Run a make target from the Makefile
+    - `target` (string, required): Target name to execute
 
 ## Contributing
 

--- a/docs/custom_makefiles.md
+++ b/docs/custom_makefiles.md
@@ -1,0 +1,426 @@
+# Creating Custom Makefiles for MCP Server Make
+
+This guide provides detailed information on creating effective custom Makefiles specifically designed to work well with MCP Server Make and Large Language Models (LLMs).
+
+## Table of Contents
+
+1. [Design Principles](#design-principles)
+2. [Structure and Organization](#structure-and-organization)
+3. [Target Naming Conventions](#target-naming-conventions)
+4. [Output Formatting](#output-formatting)
+5. [Error Handling](#error-handling)
+6. [Example Templates](#example-templates)
+7. [Working with LLMs](#working-with-llms)
+8. [Advanced Techniques](#advanced-techniques)
+
+## Design Principles
+
+When creating Makefiles for use with MCP Server Make and LLMs, focus on these core principles:
+
+### 1. Clarity
+
+LLMs understand context best when it's explicit. Your Makefile should be self-explanatory with clear target names and comments.
+
+### 2. Feedback
+
+Ensure commands provide meaningful, structured output that an LLM can parse and interpret.
+
+### 3. Robustness
+
+Commands should handle errors gracefully and be idempotent (safe to run multiple times).
+
+### 4. Discoverability
+
+Include self-documentation, help text, and descriptive comments to help the LLM understand available capabilities.
+
+### 5. Target Introduction
+
+Remember that Claude cannot automatically discover the targets in your Makefile. You must explicitly tell Claude about available targets at the beginning of each conversation. Always include a help target to make this easier.
+
+## Structure and Organization
+
+A well-structured Makefile typically includes:
+
+### Header Section
+
+Start with essential information about your Makefile:
+
+```makefile
+# Project: My Project Name
+# Author: Your Name
+# Description: This Makefile provides commands for development workflow
+# Usage: Run 'make help' to see available commands
+
+.DEFAULT_GOAL := help
+```
+
+### Help Target (Required)
+
+The `help` target is especially important for working with LLMs. It enables Claude to discover other available targets:
+
+```makefile
+help: ## Display available commands
+	@echo "Available Commands:"
+	@echo
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+```
+
+Always include this as your first interaction when introducing Claude to a new Makefile:
+
+```
+Human: Please run make help to see what commands we have available.
+```
+
+### Variable Definitions
+
+Define variables at the top for easy configuration:
+
+```makefile
+# Project settings
+PROJECT_NAME = my-project
+SRC_DIR = src
+TESTS_DIR = tests
+BUILD_DIR = build
+```
+
+### Target Groups
+
+Organize targets into logical groups with comments:
+
+```makefile
+# -----------------------------
+# Development commands
+# -----------------------------
+build: ...
+
+test: ...
+
+# -----------------------------
+# Utility commands
+# -----------------------------
+clean: ...
+
+help: ...
+```
+
+## Target Naming Conventions
+
+Use clear, descriptive target names following these conventions:
+
+### Common Standard Names
+
+Standard targets that LLMs will easily recognize:
+
+- `help`: Display available commands
+- `build`: Build the project
+- `test`: Run tests
+- `clean`: Remove build artifacts
+- `lint`: Check code style/quality
+- `format`: Auto-format code
+- `install`: Install the project
+- `deploy`: Deploy the project
+
+### Compound Names
+
+For related tasks, use consistent prefixes:
+
+```makefile
+test: ## Run all tests
+test-unit: ## Run only unit tests
+test-integration: ## Run only integration tests
+```
+
+### Task-Specific Names
+
+For specialized tasks, be descriptive and use hyphens for multi-word names:
+
+```makefile
+generate-docs: ## Generate documentation
+update-dependencies: ## Update project dependencies
+```
+
+## Output Formatting
+
+Format your command output to be easily parsable by LLMs:
+
+### Structured Output
+
+```makefile
+test:
+	@echo "=== Running Tests ==="
+	@python -m pytest $(TESTS_DIR)
+	@echo "=== Tests Complete ==="
+```
+
+### Status Headers
+
+Use clear section headers:
+
+```makefile
+build:
+	@echo "STEP 1: Cleaning old builds"
+	rm -rf $(BUILD_DIR)
+	@echo "STEP 2: Compiling source files"
+	# compilation commands
+	@echo "STEP 3: Packaging artifacts"
+	# packaging commands
+	@echo "BUILD SUCCESSFUL: Output available in $(BUILD_DIR)"
+```
+
+### Progress Indicators
+
+Show progress for long-running tasks:
+
+```makefile
+deploy:
+	@echo "[1/3] Building application..."
+	# build commands
+	@echo "[2/3] Running tests..."
+	# test commands
+	@echo "[3/3] Deploying to server..."
+	# deploy commands
+	@echo "DEPLOY COMPLETE"
+```
+
+## Error Handling
+
+Ensure your Makefile handles errors gracefully:
+
+### Error Checking
+
+```makefile
+test:
+	@echo "Running tests..."
+	@if python -m pytest $(TESTS_DIR); then \
+		echo "Tests passed successfully"; \
+	else \
+		echo "Tests failed with status $$?"; \
+		exit 1; \
+	fi
+```
+
+### Conditional Logic
+
+Handle different environments or configurations:
+
+```makefile
+install:
+	@if [ -f requirements.txt ]; then \
+		echo "Installing from requirements.txt"; \
+		pip install -r requirements.txt; \
+	elif [ -f pyproject.toml ]; then \
+		echo "Installing from pyproject.toml"; \
+		pip install -e .; \
+	else \
+		echo "ERROR: No installation files found"; \
+		exit 1; \
+	fi
+```
+
+## Example Templates
+
+Here are some template Makefiles for different project types:
+
+### Basic Development Makefile
+
+```makefile
+.DEFAULT_GOAL := help
+
+# Project settings
+PROJECT_NAME = my-project
+
+# Colors for output
+YELLOW := \033[1;33m
+GREEN := \033[1;32m
+RED := \033[1;31m
+RESET := \033[0m
+
+help: ## Display available commands
+	@echo "Available Commands:"
+	@echo
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*?##/ { printf "  $(YELLOW)%-20s$(RESET) %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+clean: ## Clean build artifacts
+	@echo "Cleaning build artifacts..."
+	rm -rf build/ dist/ *.egg-info
+
+test: ## Run tests
+	@echo "Running tests..."
+	pytest tests/
+	@echo "$(GREEN)Tests completed successfully$(RESET)"
+
+lint: ## Lint code
+	@echo "Linting code..."
+	flake8 src/
+	@echo "$(GREEN)Lint check completed$(RESET)"
+
+format: ## Format code
+	@echo "Formatting code..."
+	black src/ tests/
+	@echo "$(GREEN)Code formatted successfully$(RESET)"
+
+build: clean ## Build package
+	@echo "Building package..."
+	python -m build
+	@echo "$(GREEN)Build completed successfully$(RESET)"
+
+install: ## Install package locally
+	@echo "Installing package..."
+	pip install -e .
+	@echo "$(GREEN)Installation completed successfully$(RESET)"
+
+.PHONY: help clean test lint format build install
+```
+
+### Python Project Makefile
+
+```makefile
+.DEFAULT_GOAL := help
+
+# Project settings
+PROJECT_NAME = python-project
+SRC_DIR = src
+TESTS_DIR = tests
+VENV_DIR = .venv
+PYTHON = python3
+
+help: ## Display available commands
+	@echo "Available Commands:"
+	@echo
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+venv: ## Create virtual environment
+	@echo "Creating virtual environment..."
+	$(PYTHON) -m venv $(VENV_DIR)
+	@echo "Virtual environment created at $(VENV_DIR)"
+	@echo "Activate with: source $(VENV_DIR)/bin/activate"
+
+install-dev: ## Install development dependencies
+	@echo "Installing development dependencies..."
+	pip install -e ".[dev]"
+	@echo "Development dependencies installed"
+
+test: ## Run tests
+	@echo "Running tests..."
+	pytest $(TESTS_DIR)
+	@echo "Tests completed"
+
+lint: ## Lint code
+	@echo "Linting code with flake8..."
+	flake8 $(SRC_DIR)
+	@echo "Linting code with mypy..."
+	mypy $(SRC_DIR)
+	@echo "Lint checks completed"
+
+format: ## Format code
+	@echo "Formatting code with black..."
+	black $(SRC_DIR) $(TESTS_DIR)
+	@echo "Formatting code with isort..."
+	isort $(SRC_DIR) $(TESTS_DIR)
+	@echo "Code formatting completed"
+
+check: lint test ## Run all checks (lint, test)
+	@echo "All checks completed successfully"
+
+clean: ## Clean build artifacts
+	@echo "Cleaning build artifacts..."
+	rm -rf build/ dist/ *.egg-info __pycache__/
+	find . -type d -name __pycache__ -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+	@echo "Clean completed"
+
+.PHONY: help venv install-dev test lint format check clean
+```
+
+## Working with LLMs
+
+When using your custom Makefile with Claude through MCP Server Make, follow these practices:
+
+### Introducing Your Makefile
+
+1. **Start each new conversation with target discovery**:
+   ```
+   Human: I'm working with a custom Makefile. Let's first see what targets are available by running make help.
+   ```
+
+2. **Explain custom targets**:
+   ```
+   Human: The "analyze-code" target runs static analysis tools. The "benchmark" target measures performance.
+   ```
+
+3. **Share important context about your build system**:
+   ```
+   Human: This is a multi-stage build process. We need to run "make deps" before "make build".
+   ```
+
+### Iterative Conversations
+
+LLMs don't retain knowledge of your Makefile between sessions. For efficient collaboration:
+
+- Begin each session with `make help`
+- Reference target descriptions whenever using non-standard targets
+- If switching projects or Makefiles, be explicit about the change
+
+### Remembering Session Limitations
+
+Each time you start a new conversation with Claude, it won't remember previously discovered make targets. Plan your conversations to include necessary context at the beginning of each session.
+
+## Advanced Techniques
+
+### Self-Discovery
+
+Enable targets that help LLMs understand your codebase:
+
+```makefile
+project-info: ## Display project information
+	@echo "PROJECT INFORMATION"
+	@echo "==================="
+	@echo "Project: $(PROJECT_NAME)"
+	@echo "Version: $(shell cat VERSION 2>/dev/null || echo 'unknown')"
+	@echo "Source files: $(shell find $(SRC_DIR) -type f -name "*.py" | wc -l) Python files"
+	@echo "Test files: $(shell find $(TESTS_DIR) -type f -name "test_*.py" | wc -l) test files"
+
+list-sources: ## List all source files
+	@echo "SOURCE FILES:"
+	@find $(SRC_DIR) -type f -name "*.py" | sort
+
+list-tests: ## List all test files
+	@echo "TEST FILES:"
+	@find $(TESTS_DIR) -type f -name "test_*.py" | sort
+```
+
+### Interactive Targets
+
+Create targets that provide interactive diagnostics:
+
+```makefile
+diagnose: ## Run interactive diagnostics
+	@echo "Running system diagnostics..."
+	@echo "Python version: $(shell python --version 2>&1)"
+	@echo "Operating system: $(shell uname -a)"
+	@echo "Dependencies status:"
+	@pip list | grep -E 'pytest|black|flake8|mypy'
+	@echo "Project structure:"
+	@find . -type d -not -path "*/\.*" -not -path "*/venv*" | sort
+	@echo "Diagnostics complete"
+```
+
+### Integration with LLM Tools
+
+Create targets specifically for LLM interaction:
+
+```makefile
+llm-context: ## Generate context for LLM
+	@echo "REPOSITORY INFORMATION"
+	@echo "======================"
+	@echo "Recent commits:"
+	@git log -n5 --oneline
+	@echo "\nModified files:"
+	@git status --short
+	@echo "\nProject structure:"
+	@find . -type d -maxdepth 2 -not -path "*/\.*" | sort
+	@echo "\nKey files:"
+	@ls -la *.md *.py 2>/dev/null || echo "No key files found"
+```
+
+By following these guidelines, you can create Makefiles that work seamlessly with MCP Server Make and enable LLMs to assist more effectively with your development workflow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+# MCP Server Make Documentation
+
+Welcome to the MCP Server Make documentation. This tool enables LLMs to execute make targets from any Makefile in a safe, controlled way, creating powerful development workflows.
+
+## Documentation Index
+
+- [User Guide](user_guide.md) - Complete guide to installation, configuration, and usage
+- [Custom Makefiles](custom_makefiles.md) - Creating effective Makefiles for use with MCP Server Make
+
+## What is MCP Server Make?
+
+MCP Server Make is a Model Context Protocol (MCP) server that provides controlled access to `make` functionality. This allows Large Language Models (LLMs) like Claude to execute make targets safely, understand build processes, and assist with development tasks.
+
+The key benefit is that it creates a secure bridge between LLMs and the development environment, enabling models to:
+
+- Run build, test, and validation commands
+- Generate and validate code changes
+- Understand your project's structure and requirements
+- Help automate repetitive development tasks
+
+## Key Features
+
+- **Works with Any Makefile**: Use the included opinionated Makefile or any custom Makefile
+- **Safe Execution**: Controlled access to make functionality
+- **Flexible Configuration**: Specify custom Makefiles and working directories
+- **Error Handling**: Graceful handling of common errors
+- **Clear Output**: Structured output for LLM understanding
+
+## Getting Started
+
+See the [User Guide](user_guide.md) for complete installation and usage instructions.
+
+Quick installation:
+
+```bash
+# Using uv (recommended)
+uv pip install mcp-server-make
+
+# Using pip
+pip install mcp-server-make
+```
+
+Basic usage:
+
+```bash
+# With default Makefile in current directory
+uvx mcp-server-make
+
+# With custom Makefile and working directory
+uvx mcp-server-make --make-path /path/to/Makefile --working-dir /path/to/working/dir
+```
+
+## Resources
+
+- [GitHub Repository](https://github.com/wrale/mcp-server-make)
+- [PyPI Package](https://pypi.org/project/mcp-server-make/)
+- [Contributing Guide](../CONTRIBUTING.md)

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,334 @@
+# MCP Server Make User Guide
+
+This guide explains how to use the MCP Server Make tool effectively, with a focus on using custom Makefiles and getting the most from the integration with LLMs.
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Installation](#installation)
+3. [Basic Usage](#basic-usage)
+4. [Working with Custom Makefiles](#working-with-custom-makefiles)
+5. [Configuration Options](#configuration-options)
+6. [Integration with Claude](#integration-with-claude)
+7. [Common Workflows](#common-workflows)
+8. [Troubleshooting](#troubleshooting)
+
+## Introduction
+
+MCP Server Make is a Model Context Protocol (MCP) server that provides controlled access to `make` functionality. This allows Large Language Models (LLMs) like Claude to execute make targets safely, understand build processes, and assist with development tasks.
+
+The key benefit of MCP Server Make is that it creates a secure bridge between LLMs and the development environment, enabling models to:
+
+- Run build, test, and validation commands
+- Generate and validate code changes
+- Understand your project's structure and requirements
+- Help automate repetitive development tasks
+
+## Installation
+
+### Prerequisites
+
+- Python 3.10 or higher
+- A project with a Makefile (built-in or custom)
+
+### Installation Methods
+
+**Using `uv` (recommended):**
+```bash
+uv pip install mcp-server-make
+```
+
+**Using pip:**
+```bash
+pip install mcp-server-make
+```
+
+## Basic Usage
+
+MCP Server Make can be run directly from the command line:
+
+```bash
+# Run with default Makefile in current directory
+uvx mcp-server-make
+
+# Run with specific Makefile and working directory
+uvx mcp-server-make --make-path /path/to/Makefile --working-dir /path/to/working/dir
+```
+
+### Command-line Arguments
+
+- `--make-path`: Path to the Makefile you want to use (default: `Makefile` in current directory)
+- `--working-dir`: Directory to use as the working directory for make commands (default: directory containing the Makefile)
+
+## Working with Custom Makefiles
+
+MCP Server Make is designed to work with any valid Makefile. While the example Makefile included in the repository provides a comprehensive set of development targets, you can use your own custom Makefiles.
+
+### Using Your Own Makefile
+
+The server is completely agnostic to the actual content of your Makefile - it simply provides a secure interface to execute make targets. This means you can use:
+
+1. Complex build system Makefiles
+2. Simple task automation Makefiles
+3. Project-specific Makefiles
+4. Language-specific Makefiles
+5. Any custom Makefile of your design
+
+### Best Practices for Custom Makefiles
+
+When creating a Makefile to use with MCP Server Make and LLMs, consider the following:
+
+1. **Clear Target Names**: Use descriptive, intuitive target names that an LLM can understand
+2. **Help Documentation**: Include a `help` target that describes available commands
+3. **Informative Output**: Ensure make commands provide clear, structured output
+4. **Error Handling**: Include proper error handling and exit codes
+5. **Idempotent Commands**: Design targets to be safely executable multiple times
+6. **Self-Contained**: Minimize external dependencies where possible
+
+### Example Custom Makefile Structure
+
+Here's a simple template for a custom Makefile that works well with MCP Server Make:
+
+```makefile
+.DEFAULT_GOAL := help
+
+# Project settings
+PROJECT_NAME = my-project
+
+help: ## Display available commands
+	@echo "Available Commands:"
+	@echo
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+build: ## Build the project
+	# Your build commands here
+
+test: ## Run tests
+	# Your test commands here
+
+lint: ## Lint the code
+	# Your linting commands here
+
+clean: ## Clean build artifacts
+	# Your cleaning commands here
+
+# Define additional targets specific to your project
+```
+
+### Working Directory Considerations
+
+The `--working-dir` parameter is crucial when using custom Makefiles, as it determines:
+
+1. The directory from which make commands are executed
+2. The default location for relative paths in your Makefile
+
+If not specified, MCP Server Make uses the directory containing the specified Makefile.
+
+## Configuration Options
+
+### MCP Client Configuration
+
+To use with Claude Desktop, add to your Claude configuration (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "make": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-make",
+        "--make-path", "/absolute/path/to/Makefile",
+        "--working-dir", "/absolute/path/to/working/dir"
+      ]
+    }
+  }
+}
+```
+
+### Environment Variables
+
+MCP Server Make respects standard make environment variables, which you can set in your environment before starting the server:
+
+- `MAKEFLAGS`: Additional flags to pass to make
+- `MAKELEVEL`: Current level of make recursion
+- `MAKEFILES`: Alternate Makefiles to include
+
+### Security Considerations
+
+MCP Server Make provides a controlled interface to make, but it's important to understand that:
+
+1. It executes make with the permissions of the user running the server
+2. It has full access to the specified working directory
+3. Targets in the Makefile can execute arbitrary commands
+
+Always review your Makefile for security implications before exposing it through MCP Server Make.
+
+## Integration with Claude
+
+### Introducing Available Targets to Claude
+
+Since Claude doesn't automatically discover the available targets in your Makefile, you should explicitly tell Claude which targets are available. Here are effective approaches:
+
+1. **Start with a help command**: Begin your conversation by asking Claude to run `make help` if your Makefile has a help target. This will list available commands that Claude can then reference.
+
+   ```
+   Human: Please run make help to see what commands are available in our project.
+
+   Claude: I'll run the help command to see what's available:
+
+   [Calling make tool with args {"target": "help"}]
+   Available Commands:
+     build                Build the project
+     test                 Run tests
+     lint                 Lint code
+     format               Format code
+     clean                Clean build artifacts
+   ```
+
+2. **Explicitly list targets**: Tell Claude which targets are available and what they do.
+
+   ```
+   Human: Our Makefile has the following targets:
+   - test: Runs the test suite
+   - lint: Checks code quality
+   - format: Formats code using our style guidelines
+   Could you run the lint target?
+   ```
+
+3. **Share the Makefile content**: If appropriate, share the content of your Makefile so Claude can understand the available targets.
+
+> **Note**: Each time Claude starts a new conversation, it doesn't remember previously discovered targets. You'll need to reintroduce the available targets at the beginning of each conversation or when switching contexts.
+
+### Working with Claude
+
+Claude can interact with your make targets through the MCP Server Make interface. This enables powerful workflows where Claude can:
+
+### For Development Tasks
+
+1. **Run Tests and Report Results**
+   - `make test` to run tests
+   - Parse and explain test output
+   - Suggest fixes for failing tests
+
+2. **Analyze Code Quality**
+   - `make lint` to check code quality
+   - Summarize and explain linting errors
+   - Help implement fixes
+
+3. **Manage Build Processes**
+   - `make build` to build projects
+   - Understand and explain build errors
+   - Help optimize build configurations
+
+### For Project Management
+
+1. **Track Project Status**
+   - Use custom reporting targets like `make status`
+   - Get summaries of project health
+   - Monitor progress over time
+
+2. **Automate Documentation**
+   - Generate docs with targets like `make docs`
+   - Update documentation when code changes
+   - Create new documentation for undocumented features
+
+### Example Interaction with Claude
+
+```
+Human: Can you check if our tests are passing?
+
+Claude: I'll check the test status for you:
+
+[Calling make tool with args {"target": "test"}]
+Running tests...
+4 passed, 0 failed
+
+Great news! All 4 tests are passing. The test suite completed successfully.
+
+Would you like me to run any other checks on the codebase?
+```
+
+## Common Workflows
+
+### Development Assistance
+
+```
+# Check code quality
+make lint
+
+# Format code
+make format
+
+# Run tests
+make test
+
+# Full validation
+make check
+```
+
+### Project Understanding
+
+The included repository Makefile provides some utility targets for project understanding, but these are specific to this repository's Makefile and not universal:
+
+```
+# View project structure (specific to this repository's Makefile)
+make x
+
+# Check recent changes (specific to this repository's Makefile)
+make z
+
+# Full context snapshot (specific to this repository's Makefile)
+make r
+```
+
+You can create similar targets in your own Makefiles to help Claude understand your project structure.
+
+### Automation
+
+Custom targets can be created for any repetitive task:
+
+```makefile
+deploy: ## Deploy the application
+    # Deployment commands
+
+update-deps: ## Update dependencies
+    # Dependency update commands
+
+generate-report: ## Generate status report
+    # Report generation commands
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Makefile not found"**: 
+   - Verify the `--make-path` points to a valid Makefile
+   - Check file permissions
+
+2. **"Working directory error"**: 
+   - Ensure `--working-dir` exists and is accessible
+   - Check directory permissions
+
+3. **"Tool execution failed"**: 
+   - Check the make target exists in your Makefile
+   - Verify the command succeeds when run manually
+   - Look for syntax errors in your Makefile
+
+4. **"Permission denied"**: 
+   - Check file and directory permissions
+   - Ensure the user running the server has appropriate access
+
+### Debugging Tips
+
+1. **Test make commands directly** before using them through MCP Server Make
+2. **Review make output** carefully for error messages
+3. **Start with simple targets** and gradually introduce complexity
+4. **Use verbose flags** in your Makefile for debugging
+
+### Getting Help
+
+If you encounter issues with MCP Server Make, check:
+- The GitHub repository issues page
+- The project documentation
+- Community forums for MCP and Claude integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-server-make"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Model Context Protocol server providing access to make functionality"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This commit provides complete documentation for using MCP Server Make with any Makefile:

- Clarifies that MCP Server Make works with any Makefile, not just the included one
- Adds explicit guidance on how to introduce make targets to Claude, as they're not automatically discovered
- Adds a docs directory with:
  - User guide explaining installation, configuration, and usage
  - Custom Makefiles guide with best practices and conversation strategies
  - Documentation index for navigation
- Restructures the README to be more concise with links to detailed documentation
- Highlights the importance of 'make help' as the first interaction in each conversation
- Clearly marks repository-specific targets like 'make x', 'make z', etc.
- Provides detailed guidance for creating effective Makefiles for LLM interaction

These changes significantly improve the UX by setting proper expectations about target discovery and providing actionable guidance for working with Claude.